### PR TITLE
Fixed a link from Fragment Specifiers to TokenTree syntax.

### DIFF
--- a/src/macros/minutiae/fragment-specifiers.md
+++ b/src/macros/minutiae/fragment-specifiers.md
@@ -230,7 +230,7 @@ paths! {
 ## `tt`
 
 The `tt` fragment matches a TokenTree. If you need a refresher on what exactly a TokenTree was you
-may want to revisit the [TokenTree chapter](.macros/syntax/source-analysys.html#token-trees) of this
+may want to revisit the [TokenTree chapter](../syntax/source-analysys.html#token-trees) of this
 book. The `tt` fragment is one of the most powerful fragments, as it can match nearly anything while
 still allowing you to inspect the contents of it at a later state in the macro.
 


### PR DESCRIPTION
Fixing a link in http://[::1]:3000/macros/minutiae/fragment-specifiers.html#tt > "you may want to revisit the TokenTree chapter".