### PR TITLE
Fix errors relating to `-Zunpretty=expanded`.

### DIFF
--- a/src/decl-macros/macros-practical.md
+++ b/src/decl-macros/macros-practical.md
@@ -972,11 +972,10 @@ error[E0425]: cannot find value `n` in this scope
 That can't be right... let's check what the macro is expanding to.
 
 ```shell
-$ rustc -Z unstable-options --pretty expanded recurrence.rs
+$ rustc +nightly -Zunpretty=expanded recurrence.rs
 ```
 
-The `--pretty expanded` argument tells `rustc` to perform macro expansion, then turn the resulting AST back into source code.
-Because this option isn't considered stable yet, we also need `-Z unstable-options`.
+The `-Zunpretty=expanded` argument tells `rustc` to perform macro expansion, then turn the resulting AST back into source code.
 The output (after cleaning up some formatting) is shown below;
 in particular, note the place in the code where `$recur` was substituted:
 
@@ -1117,7 +1116,7 @@ As you can see, the <code><span class="synctx-1">a</span></code> that's defined 
 As such, the compiler treats them as completely different identifiers, *even though they have the same lexical appearance*.
 
 This is something to be *really* careful of when working on `macro_rules!` macros, syntax extensions in general even: they can produce ASTs which
-will not compile, but which *will* compile if written out by hand, or dumped using `--pretty expanded`.
+will not compile, but which *will* compile if written out by hand, or dumped using `-Zunpretty=expanded`.
 
 The solution to this is to capture the identifier *with the appropriate syntax context*.
 To do that, we need to again adjust our macro syntax.

--- a/src/syntax-extensions/debugging.md
+++ b/src/syntax-extensions/debugging.md
@@ -4,7 +4,7 @@
 
 
 Sometimes, it is what the extension *expands to* that proves problematic as you do not usually see the expanded code.
-Fortunately `rustc` offers the ability to look at the expanded code, for this, the `--pretty` argument can be used.
+Fortunately `rustc` offers the ability to look at the expanded code via the unstable `-Zunpretty=expanded` argument.
 Given the following code:
 
 ```rust,ignore
@@ -22,7 +22,7 @@ fn main() {
 compiled with the following command:
 
 ```shell
-rustc -Z unstable-options -Zunpretty=expanded hello.rs
+rustc +nightly -Zunpretty=expanded hello.rs
 ```
 
 produces the following output (modified for formatting):
@@ -54,6 +54,6 @@ fn main() {
 ```
 
 But not just `rustc` exposes means to aid in debugging syntax extensions.
-For the aforementioned `--pretty=expanded` option, there exists a nice `cargo` plugin called [`cargo-expand`](https://github.com/dtolnay/cargo-expand) made by [`dtolnay`](https://github.com/dtolnay) which is basically just a wrapper around it.
+For the aforementioned `-Zunpretty=expanded` option, there exists a nice `cargo` plugin called [`cargo-expand`](https://github.com/dtolnay/cargo-expand) made by [`dtolnay`](https://github.com/dtolnay) which is basically just a wrapper around it.
 
 You can also use the [playground](https://play.rust-lang.org/), clicking on its `TOOLS` button in the top right gives you the option to expand syntax extensions as well!


### PR DESCRIPTION
- It's called `-Zunpretty`, not `-Zpretty`.
- It requires a nightly compiler.
- `-Zunstable-options` is not required.