### PR TITLE
Add contents and Fix broken links

### DIFF
--- a/src/decl-macros/minutiae/metavar-and-expansion.md
+++ b/src/decl-macros/minutiae/metavar-and-expansion.md
@@ -25,13 +25,15 @@ restricts what can follow various metavariables.
 The complete list, showing what may follow what fragment specifier, as of Rust 1.46 is as follows:
 
 * [`stmt`] and [`expr`]: `=>`, `,`, or `;`
-* [`pat`]: `=>`, `,`, `=`, `if`, `in`
+* [`pat`]: `=>`, `,`, `=`, `if`, `in`[^pat-edition]
 * [`pat_param`]: `=>`, `,`, `=`, `|`, `if`, `in`
 * [`path`] and [`ty`]:`=>`, `,`, `=`, `|`, `;`, `:`, `>`, `>>`, `[`, `{`, `as`, `where`, or a macro
     variable of the [`block`] fragment specifier.
 * [`vis`]: `,`, an identifier other than a non-raw `priv`, any token that can begin a type or a
     metavariable with an [`ident`], [`ty`], or [`path`] fragment specifier.
 * All other fragment specifiers have no restrictions.
+
+[^pat-edition]: **Edition Differences**: Before the 2021 edition, `pat` may also be followed by `|`.
 
 Repetitions also adhere to these restrictions, meaning if a repetition can repeat multiple times(`*` or `+`), then the contents must be able to follow themselves.
 If a repetition can repeat zero times (`?` or `*`) then what comes after the repetition must be able to follow what comes before.

--- a/src/decl-macros/minutiae/metavar-expr.md
+++ b/src/decl-macros/minutiae/metavar-expr.md
@@ -11,9 +11,9 @@ This chapter will introduce them more in-depth together with usage examples.
 
 - [`$$`](#dollar-dollar-)
 - [`${count(ident, depth)}`](#countident-depth)
-- [`${index(depth)}`](#index-depth)
-- [`${length(depth)}`](#length-depth)
-- [`${ignore(ident)}`](#ignore-ident)
+- [`${index(depth)}`](#indexdepth)
+- [`${length(depth)}`](#lengthdepth)
+- [`${ignore(ident)}`](#ignoreident)
 
 ## Dollar Dollar (`$$`)
 
@@ -36,7 +36,7 @@ foo!();
 ```
 
 The problem is obvious, the transcriber of foo sees a repetition and tries to repeat it when transcribing, but there is no `$any` metavariable in its scope causing it to fail.
-With `$$` we can get around this as the transcriber of `foo` will no longer try to do the repetition.
+With `$$` we can get around this as the transcriber of `foo` will no longer try to do the repetition.[^tt-$]
 
 ```rust
 #![feature(macro_metavar_expr)]
@@ -53,6 +53,9 @@ foo!();
 bar!();
 # fn main() {}
 ```
+
+[^tt-$]: Before `$$` occurs, users must resort to a tricky and not so well-known hack to declare nested macros with repetitions
+         [via using `$tt` like this](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=9ce18fc79ce17c77d20e74f3c46ee13c).
 
 ## `count(ident, depth)`
 


### PR DESCRIPTION
Add:
- the edition differences statement for `$pat`
- a hack example before `$$` occurs

Fix: broken links