### PR TITLE
Fix C snippet

### DIFF
--- a/src/syntax-extensions/source-analysis.md
+++ b/src/syntax-extensions/source-analysis.md
@@ -34,7 +34,7 @@ Rust does *not*. For example, C/C++ macros are *effectively* processed at this p
 [^cpp-it-seemed-like-a-good-idea-at-the-time]
 
 ```c
-#define SUB void
+#define SUB int
 #define BEGIN {
 #define END }
 


### PR DESCRIPTION
This is not really related to Rust, but the current _main_ function definition in the code snippet isn't valid C, as the C standard requires the return type of _main_ to be _int_ (C11 standard, §5.1.2.2.1 Program startup).
It's not important for the demonstration here but it just bothered me...