### PR TITLE
Added extra 'changed' annotation in macros-practical

### DIFF
--- a/src/decl-macros/macros-practical.md
+++ b/src/decl-macros/macros-practical.md
@@ -1186,7 +1186,7 @@ macro_rules! recurrence {
                             let $ind = self.pos;
 //                              ^~~~ changed
                             let $seq = IndexOffset { slice: &self.mem, offset: $ind };
-//                              ^~~~ changed
+//                              ^~~~ changed                                   ^~~~ changed
                             $recur
                         };
 


### PR DESCRIPTION
Added a changed annotation in one of the block codes in macros-practical since when reading the book to learn how rust macros work I missed this change because the annotation wasn't there.