### PR TITLE
Fix test failures.

### DIFF
--- a/src/decl-macros/building-blocks/parsing.md
+++ b/src/decl-macros/building-blocks/parsing.md
@@ -27,13 +27,13 @@ macro_rules! function_item_matcher {
     }
 }
 
-#function_item_matcher!(
-#    #[inline]
-#    #[cold]
-#    pub fn foo(bar: i32, baz: i32, ) -> String {
-#        format!("{} {}", bar, baz)
-#    }
-#);
+# function_item_matcher!(
+#     #[inline]
+#     #[cold]
+#     pub fn foo(bar: i32, baz: i32, ) -> String {
+#         format!("{} {}", bar, baz)
+#     }
+# );
 #
 # fn main() {
 #     assert_eq!(foo(13, 37), "13 37");
@@ -114,27 +114,27 @@ macro_rules! struct_item_matcher {
     }
 }
 
-#struct_item_matcher!(
-#    #[derive(Copy, Clone)]
-#    pub(crate) struct Foo {
-#       pub bar: i32,
-#       baz: &'static str,
-#       qux: f32
-#    }
-#);
-#struct_item_matcher!(
-#    #[derive(Copy, Clone)]
-#    pub(crate) struct Bar;
-#);
-#struct_item_matcher!(
-#    #[derive(Clone)]
-#    pub(crate) struct Baz (i32, pub f32, String);
-#);
-#fn main() {
-#    let _: Foo = Foo { bar: 42, baz: "macros can be nice", qux: 3.14, };
-#    let _: Bar = Bar;
-#    let _: Baz = Baz(2, 0.1234, String::new());
-#}
+# struct_item_matcher!(
+#     #[derive(Copy, Clone)]
+#     pub(crate) struct Foo {
+#        pub bar: i32,
+#        baz: &'static str,
+#        qux: f32
+#     }
+# );
+# struct_item_matcher!(
+#     #[derive(Copy, Clone)]
+#     pub(crate) struct Bar;
+# );
+# struct_item_matcher!(
+#     #[derive(Clone)]
+#     pub(crate) struct Baz (i32, pub f32, String);
+# );
+# fn main() {
+#     let _: Foo = Foo { bar: 42, baz: "macros can be nice", qux: 3.14, };
+#     let _: Bar = Bar;
+#     let _: Baz = Baz(2, 0.1234, String::new());
+# }
 ```
 
 # Enum
@@ -191,25 +191,25 @@ macro_rules! enum_item_matcher {
     };
 }
 
-#enum_item_matcher!(
-#    #[derive(Copy, Clone)]
-#    pub(crate) enum Foo {
-#        Bar,
-#        Baz,
-#    }
-#);
-#enum_item_matcher!(
-#    #[derive(Copy, Clone)]
-#    pub(crate) enum Bar {
-#        Foo(i32, f32),
-#        Bar,
-#        Baz(),
-#    }
-#);
-#enum_item_matcher!(
-#    #[derive(Clone)]
-#    pub(crate) enum Baz {}
-#);
+# enum_item_matcher!(
+#     #[derive(Copy, Clone)]
+#     pub(crate) enum Foo {
+#         Bar,
+#         Baz,
+#     }
+# );
+# enum_item_matcher!(
+#     #[derive(Copy, Clone)]
+#     pub(crate) enum Bar {
+#         Foo(i32, f32),
+#         Bar,
+#         Baz(),
+#     }
+# );
+# enum_item_matcher!(
+#     #[derive(Clone)]
+#     pub(crate) enum Baz {}
+# );
 ```
 
 [patterns]: ../patterns.md

--- a/src/decl-macros/macros-methodical.md
+++ b/src/decl-macros/macros-methodical.md
@@ -220,7 +220,7 @@ repeat_two!( a b c d e f, u v w x y z );
 
 But this does not:
 
-```rust
+```rust,compile_fail
 # macro_rules! repeat_two {
 #     ($($i:ident)*, $($i2:ident)*) => {
 #         $( let $i: (); let $i2: (); )*
@@ -232,7 +232,7 @@ repeat_two!( a b c d e f, x y z );
 
 failing with the following error
 
-```
+```text
 error: meta-variable `i` repeats 6 times, but `i2` repeats 3 times
  --> src/main.rs:6:10
   |

--- a/src/decl-macros/macros-practical.md
+++ b/src/decl-macros/macros-practical.md
@@ -374,7 +374,7 @@ Success!
 Now, let's copy & paste this into the macro expansion, and replace the expanded code with an invocation.
 This gives us:
 
-```rust
+```rust,compile_fail
 macro_rules! recurrence {
     ( a[n]: $sty:ty = $($inits:expr),+ , ... , $recur:expr ) => {
         {
@@ -489,7 +489,7 @@ Theoretically, this *should* work as desired, but currently doesn't.
 Thankfully, the fix is relatively simple: we remove the comma from the syntax.
 To keep things balanced, we'll remove *both* commas around `...`:
 
-```rust
+```rust,compile_fail
 macro_rules! recurrence {
     ( a[n]: $sty:ty = $($inits:expr),+ ... $recur:expr ) => {
 //                                     ^~~ changed
@@ -866,7 +866,7 @@ macro_rules! recurrence {
 
 With that done, we can now substitute the last thing: the `recur` expression.
 
-```rust
+```rust,compile_fail
 # macro_rules! count_exprs {
 #     () => (0);
 #     ($head:expr $(, $tail:expr)*) => (1 + count_exprs!($($tail),*));

--- a/src/decl-macros/macros2.md
+++ b/src/decl-macros/macros2.md
@@ -13,7 +13,8 @@ Nothing described here is final or complete, and may be subject to change.
 
 We'll do a comparison between the `macro` and `macro_rules` syntax for two macros we have implemented in previous chapters:
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(decl_macro)]
 
 macro_rules! replace_expr_ {
@@ -60,7 +61,8 @@ Unlike `macro_rules` which have [mixed site hygiene], `macro` have definition si
 
 As such the following compiles with a `macro_rules` macro, but fails with a `macro` definition:
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(decl_macro)]
 // try uncommenting the following line, and commenting out the line right after
 

--- a/src/decl-macros/minutiae/debugging.md
+++ b/src/decl-macros/minutiae/debugging.md
@@ -50,8 +50,8 @@ You can also enable this from the command-line by adding `-Z trace-macros` to th
 Secondly, there is [`log_syntax!`] which causes the compiler to output all tokens passed to it.
 For example, this makes the compiler sing a song:
 
-```rust
-# // Note: make sure to use a nightly channel compiler.
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(log_syntax)]
 
 macro_rules! sing {

--- a/src/decl-macros/minutiae/fragment-specifiers.md
+++ b/src/decl-macros/minutiae/fragment-specifiers.md
@@ -162,7 +162,7 @@ metas! {
 
 The `pat` fragment matches any kind of [pattern](https://doc.rust-lang.org/reference/patterns.html), including or-patterns starting with the 2021 edition.
 
-```rust
+```rust,edition2021
 macro_rules! patterns {
     ($($pat:pat)*) => ();
 }
@@ -329,7 +329,7 @@ visibilities! {
 While able to match empty sequences of tokens, the fragment specifier still acts quite different from [optional repetitions](../macros-methodical.md#repetitions) which is described in the following:
 
 If it is being matched against no left over tokens the entire macro matching fails.
-```rust
+```rust,compile_fail
 macro_rules! non_optional_vis {
     ($vis:vis) => ();
 }
@@ -337,13 +337,16 @@ non_optional_vis!();
 // ^^^^^^^^^^^^^^^^ error: missing tokens in macro arguments
 ```
 
-`$vis:vis $ident:ident` matches fine, unlike `$(pub)? $ident:ident` which is ambiguous, as `pub` denotes a valid identifier.
+`$vis:vis $ident:ident` matches fine.
 ```rust
 macro_rules! vis_ident {
     ($vis:vis $ident:ident) => ();
 }
 vis_ident!(pub foo); // this works fine
+```
 
+In contrast, `$(pub)? $ident:ident` is ambiguous, as `pub` denotes a valid identifier.
+```rust,compile_fail
 macro_rules! pub_ident {
     ($(pub)? $ident:ident) => ();
 }

--- a/src/decl-macros/minutiae/identifiers.md
+++ b/src/decl-macros/minutiae/identifiers.md
@@ -36,7 +36,7 @@ So `self` is both a keyword and not a keyword at the same time.
 You might wonder how this is in any way important.
 Take this example:
 
-```rust
+```rust,compile_fail
 macro_rules! make_mutable {
     ($i:ident) => {let mut $i = $i;};
 }
@@ -74,7 +74,7 @@ error: `mut` must be followed by a named binding
 So the macro will happily match `self` as an identifier, allowing you to use it in cases where you can't actually use it.
 But, fine; it somehow remembers that `self` is a keyword even when it's an identifier, so you *should* be able to do this, right?
 
-```rust
+```rust,compile_fail
 macro_rules! make_self_mutable {
     ($i:ident) => {let mut $i = self;};
 }
@@ -117,7 +117,7 @@ Now the compiler thinks we refer to our module with `self`, but that doesn't mak
 We already have a `self` right there, in the function signature which is definitely not a module.
 It's almost like it's complaining that the `self` it's trying to use isn't the *same* `self`... as though the `self` keyword has hygiene, like an... identifier.
 
-```rust
+```rust,compile_fail
 macro_rules! double_method {
     ($body:expr) => {
         fn double(mut self) -> Dummy {
@@ -169,7 +169,7 @@ At last, *this works*.
 So `self` is both a keyword *and* an identifier when it feels like it.
 Surely this works for other, similar constructs, right?
 
-```rust
+```rust,compile_fail
 macro_rules! double_method {
     ($self_:ident, $body:expr) => {
         fn double($self_) -> Dummy {

--- a/src/decl-macros/minutiae/metavar-and-expansion.md
+++ b/src/decl-macros/minutiae/metavar-and-expansion.md
@@ -42,7 +42,7 @@ The parser also does not perform any kind of lookahead.
 That means if the compiler cannot unambiguously determine how to parse the macro invocation one token at a time, it will abort with an ambiguity error.
 A simple example that triggers this:
 
-```rust
+```rust,compile_fail
 macro_rules! ambiguity {
     ($($i:ident)* $i2:ident) => { };
 }

--- a/src/decl-macros/minutiae/metavar-expr.md
+++ b/src/decl-macros/minutiae/metavar-expr.md
@@ -21,7 +21,7 @@ The `$$` expression expands to a single `$`, making it effectively an escaped `$
 This enables the ability in writing macros emitting new macros as the former macro won't transcribe metavariables, repetitions and metavariable expressions that have an escaped `$`.
 
 We can see the problem without using `$$` in the following snippet:
-```rust
+```rust,compile_fail
 macro_rules! foo {
     () => {
         macro_rules! bar {
@@ -38,7 +38,8 @@ foo!();
 The problem is obvious, the transcriber of foo sees a repetition and tries to repeat it when transcribing, but there is no `$any` metavariable in its scope causing it to fail.
 With `$$` we can get around this as the transcriber of `foo` will no longer try to do the repetition.[^tt-$]
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(macro_metavar_expr)]
 
 macro_rules! foo {
@@ -67,7 +68,8 @@ The `count` metavariable expression expands to the repetition count of the metav
 
 The `count(ident)` expression defaults `depth` to the maximum valid depth, making it count the total repetitions for the given metavariable.
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(macro_metavar_expr)]
 
 macro_rules! foo {
@@ -97,7 +99,8 @@ The `index(depth)` metavariable expression expands to the current iteration inde
 
 The `index()` expression defaults `depth` to `0`, making it a shorthand for `index(0)`.
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(macro_metavar_expr)]
 
 macro_rules! attach_iteration_counts {
@@ -134,7 +137,8 @@ The `length(depth)` metavariable expression expands to the iteration count of th
 The `length()` expression defaults `depth` to `0`, making it a shorthand for `length(0)`.
 
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(macro_metavar_expr)]
 
 macro_rules! lets_count {
@@ -166,7 +170,8 @@ The `ignore(ident)` metavariable expression expands to nothing, making it possib
 
 - The `ident` argument must be a declared metavariable in the scope of the rule.
 
-```rust
+```rust,ignore
+# // This code block marked `ignore` because mdbook can't handle `#![feature(...)]`.
 #![feature(macro_metavar_expr)]
 
 macro_rules! repetition_tuples {

--- a/src/decl-macros/patterns/callbacks.md
+++ b/src/decl-macros/patterns/callbacks.md
@@ -29,6 +29,14 @@ An alternative is to use recursion and pass a callback:
 
 ```rust
 // ...
+# macro_rules! recognize_tree {
+#     (larch) => { println!("#1, the Larch.") };
+#     (redwood) => { println!("#2, the Mighty Redwood.") };
+#     (fir) => { println!("#3, the Fir.") };
+#     (chestnut) => { println!("#4, the Horse Chestnut.") };
+#     (pine) => { println!("#5, the Scots Pine.") };
+#     ($($other:tt)*) => { println!("I don't know; some kind of birch maybe?") };
+# }
 
 macro_rules! call_with_larch {
     ($callback:ident) => { $callback!(larch) };


### PR DESCRIPTION
`mdbook test` reports lots of errors. This commit fixes them, in various ways.
- Add space after `#` on hidden lines.
- Add `compile_fail` to all examples that are intended to not compile.
- Add `text` to non-code blocks.
- Add `ignore` to examples using `#![feature(...)]`, which requires nightly. Unfortunate, but I can't see a better way to handle these.
- Add `edition2021` where necessary.
- Add necessary hidden code.