### PR TITLE
Rename ${length()} to ${len()}

### DIFF
--- a/src/decl-macros/macros-methodical.md
+++ b/src/decl-macros/macros-methodical.md
@@ -257,8 +257,8 @@ The following expressions are available with `ident` being the name of a bound m
 - `${count(ident, depth)}`: The number of times `$ident` repeats in the repetition at `depth`.
 - `${index()}`: The current repetition index of the inner-most repetition. This is equivalent to `${index(0)}`.
 - `${index(depth)}`: The current index of the repetition at `depth`, counting outwards.
-- `${length()}`: The number of times the inner-most repetition will repeat for. This is equivalent to `${length(0)}`.
-- `${length(depth)}`: The number of times the repetition at `depth` will repeat for, counting outwards.
+- `${len()}`: The number of times the inner-most repetition will repeat for. This is equivalent to `${len(0)}`.
+- `${len(depth)}`: The number of times the repetition at `depth` will repeat for, counting outwards.
 - `${ignore(ident)}`: Binds `$ident` for repetition, while expanding to nothing.
 - `$$`:	Expands to a single `$`, effectively escaping the `$` token so it won't be transcribed.
 

--- a/src/decl-macros/minutiae/metavar-expr.md
+++ b/src/decl-macros/minutiae/metavar-expr.md
@@ -13,7 +13,7 @@ This chapter will introduce them more in-depth together with usage examples.
   - [Dollar Dollar (`$$`)](#dollar-dollar-)
   - [`count($ident, depth)`](#countident-depth)
   - [`index(depth)`](#indexdepth)
-  - [`length(depth)`](#lengthdepth)
+  - [`len(depth)`](#lengthdepth)
   - [`ignore($ident)`](#ignoreident)
 
 ## Dollar Dollar (`$$`)
@@ -128,14 +128,14 @@ fn main() {
 ```
 
 
-## `length(depth)`
+## `len(depth)`
 
-The `length(depth)` metavariable expression expands to the iteration count of the repetition at the given depth.
+The `len(depth)` metavariable expression expands to the iteration count of the repetition at the given depth.
 
 - The `depth` argument targets the repetition at `depth` counting outwards from the inner-most repetition where the expression is invoked.
 - The expression expands to an unsuffixed integer literal token.
 
-The `length()` expression defaults `depth` to `0`, making it a shorthand for `length(0)`.
+The `len()` expression defaults `depth` to `0`, making it a shorthand for `len(0)`.
 
 
 ```rust,ignore
@@ -148,8 +148,8 @@ macro_rules! lets_count {
             $(
                 println!(
                     "'{}' in inner iteration {}/{} with '{}' in outer iteration {}/{} ",
-                    stringify!($inner), ${index()}, ${length()},
-                    stringify!($outer), ${index(1)}, ${length(1)},
+                    stringify!($inner), ${index()}, ${len()},
+                    stringify!($outer), ${index(1)}, ${len(1)},
                 );
             )*
         )*


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/rust/pull/124987, `${length()}` has been renamed to `${len()}`.